### PR TITLE
Add comment form to osusume page

### DIFF
--- a/app/assets/stylesheets/novels.scss
+++ b/app/assets/stylesheets/novels.scss
@@ -67,4 +67,5 @@
 
 .white{
   color: white;
+  height: 10px;
 }

--- a/app/assets/stylesheets/osusumes.scss
+++ b/app/assets/stylesheets/osusumes.scss
@@ -44,7 +44,6 @@ body{
 }
 .card-footer{
   background-color: white !important;
-  height: 35px;
   .description{
     font-size: 10px;
     position: absolute;
@@ -109,4 +108,21 @@ body{
   text-decoration: underline;
   font-weight: bold;
   font-size: 18px;
+}
+
+.osusume__comment-form{
+  padding: 5px;
+  outline: none;
+  border: 1px solid rgb(235, 235, 235);
+  border-radius: 5px;
+  -webkit-transition: all .3s;
+  transition: all .3s;
+  &:focus{
+    box-shadow: 0 0 7px #1abc9c;
+    border: 1px solid #1abc9c;
+  }
+}
+
+.osusume__comment-form__button{
+  border-radius: 100px !important;
 }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -28,9 +28,12 @@ class CommentsController < ApplicationController
 
     respond_to do |format|
       if @comment.save
-        format.html { redirect_to @comment, notice: 'Comment was successfully created.' }
-        format.json { render :show, status: :created, location: @comment }
-        format.js
+        # コメント書いた際に、ajaxから、小説詳細ページへ飛ぶように変更。
+        format.html { redirect_to @comment.novel, notice: 'Comment was successfully created.' }
+        format.json { render :show, status: :created, location: @comment.novel }
+        # format.html { redirect_to @comment, notice: 'Comment was successfully created.' }
+        # format.json { render :show, status: :created, location: @comment }
+        # format.js
       else
         format.html { render :new }
         format.json { render json: @comment.errors, status: :unprocessable_entity }

--- a/app/views/novels/_comment-card.html.haml
+++ b/app/views/novels/_comment-card.html.haml
@@ -1,21 +1,23 @@
 .comment-card.card.my-2.mx-0.border-0
-  .comment-name.text-muted.p-2
-    名前: #{comment.name}
+  .p-2
   - up_down_rate = ((comment.up.to_f) / (comment.up.to_f + comment.down.to_f)) * 100
   - if    75 <= up_down_rate
-    .px-2.pt-2.pb-0.comment.comment-level-5
+    .px-3.pt-1.pb-4.comment.comment-level-5
       #{comment.comment}
   - elsif 60 <= up_down_rate  && up_down_rate < 75
-    .px-2.pt-2.pb-0.comment.comment-level-4
+    .px-3.pt-1.pb-4.comment.comment-level-4
       #{comment.comment}
   - elsif 25 <= up_down_rate  && up_down_rate < 60
-    .px-2.pt-2.pb-0.comment.comment-level-3
+    .px-3.pt-1.pb-4.comment.comment-level-3
       #{comment.comment}
   - elsif 10 <= up_down_rate  && up_down_rate < 25
-    .px-2.pt-2.pb-0.comment.comment-level-2
+    .px-3.pt-1.pb-4.comment.comment-level-2
+      #{comment.comment}
+  - elsif up_down_rate < 10
+    .px-3.pt-1.pb-4.comment.comment-level-2
       #{comment.comment}
   - else
-    .px-2.pt-2.pb-0.comment.comment-level-1
+    .px-3.pt-1.pb-4.comment.comment-level-3
       #{comment.comment}
   .container.mb-0.mt-3.pr-1
     .row.mx-auto.d-flex.justify-content-end.comment-bottom-content

--- a/app/views/novels/show.html.haml
+++ b/app/views/novels/show.html.haml
@@ -22,15 +22,11 @@
         .fa.fa-pencil.mr-1
         レビューする →
   %hr
-  【レビュー】
-  - @novel.reviews.each do |review|
-    = render partial: "layouts/review-card", locals: { review: review}
+  - if @novel.reviews.present?
+    【レビュー】
+    - @novel.reviews.each do |review|
+      = render partial: "layouts/review-card", locals: { review: review}
 
-  %hr
-  = render partial: "layouts/popular-osusumes", locals: { osusumes: @osusumes }
-
-
-  【コメント】
   #comment-cards
     - @comments.each do |comment|
       = render partial: "comment-card", locals: { comment: comment}
@@ -41,6 +37,9 @@
   -#   レビューする →
 
   = render partial: "comment-form", locals: { comment: @comment}
+
+  %hr
+  = render partial: "layouts/popular-osusumes", locals: { osusumes: @osusumes }
 
 -# TODO modalをつけるかどうかを判断
   -# .row.m-3

--- a/app/views/osusumes/_comment-form.html.haml
+++ b/app/views/osusumes/_comment-form.html.haml
@@ -1,0 +1,7 @@
+.mx-auto
+  = form_for  Comment.new(name: 'なろう好き', novel_id: novel.id), :remote => true do |f|
+    .form-group
+      = f.text_area :comment, :placeholder=>'好きなところを聞かせてください！', id: "comment-comment", class: "d-block w-100 osusume__comment-form", required: "required", style: "height: 80px;"
+    = f.hidden_field :novel_id, :value => novel.id
+    .mt-2.mb-3
+      = f.submit "コメントする", class: "btn btn-primary px-3 mx-auto font-weight-bold osusume__comment-form__button d-block osusume__comment-form__button", data: { disable_with: "コメントする"}

--- a/app/views/osusumes/_novel-card.html.haml
+++ b/app/views/osusumes/_novel-card.html.haml
@@ -48,6 +48,7 @@
           %span.font-weight-bold.pr-1
             kindle
   .card-footer.mt-1
+    = render partial: "comment-form", locals: { comment: Comment.new(name: 'なろう好き', novel_id: novel.id), novel: novel}
     .white
       #{novel.id}
     = link_to novel_path(novel.id), target: "_blank"  do


### PR DESCRIPTION
おすすめ画面の小説ごとに、コメントフォームを設置、コメントできるようにした。

コメント後に小説画面へ飛ぶように設計。